### PR TITLE
Correct output indentation levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1279,9 +1279,9 @@
       }
     },
     "general-language-syntax": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/general-language-syntax/-/general-language-syntax-0.3.18.tgz",
-      "integrity": "sha512-RsmXTcZDBPT20remMveTPuT+ML1eO+pd5uc7r65F/oTM7HdAGvEh8caEzsf6D4/OmZBXc8y4IrLV3EjUZQkz1A=="
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/general-language-syntax/-/general-language-syntax-0.3.20.tgz",
+      "integrity": "sha512-9ix7NHD9oOhL9SDkPWQdJiyQR3WeI06FSc6W6nEnBXg4zqq+2OIC/EnYfkDQA9wuw7EeccyDpfr527yDRkhrIA=="
     },
     "get-func-name": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@types/mz": "0.0.32",
-    "general-language-syntax": "^0.3.18",
+    "general-language-syntax": "^0.3.20",
     "mz": "^2.7.0",
     "tsutils": "^2.9.0"
   }

--- a/src/lineIndenter.ts
+++ b/src/lineIndenter.ts
@@ -1,0 +1,80 @@
+import { CommandsBag } from "general-language-syntax";
+
+import { GlsLine } from "./glsLine";
+
+/**
+ * Generates spaces equivalent to 4-space code tabbing.
+ *
+ * @param amount   How many tabs should be added.
+ * @returns An all-spaces String of length = amount * 4.
+ */
+const generateTabs = (amount: number): string => {
+    let output = "";
+
+    for (let i = 0; i < amount; i += 1) {
+        output += "    ";
+    }
+
+    return output;
+};
+
+/**
+ * Indents GLS lines using their command metadata.
+ */
+export class LineIndenter {
+    private readonly commandsBag: CommandsBag = CommandsBag.forLanguageName("TypeScript");
+
+    /**
+     * Indents GLS lines using their command metadata.
+     *
+     * @param lines   GLS and literal string lines.
+     * @returns Indented versions of the lines.
+     */
+    public indent(lines: (string | GlsLine)[]): string[] {
+        const output: string[] = [];
+        let currentIndentation = 0;
+
+        for (const line of lines) {
+            if (typeof line === "string") {
+                output.push("");
+                continue;
+            }
+
+            const indentationChanges = this.getIndentationChanges(line);
+            const stringified = line.toString();
+
+            for (const change of indentationChanges) {
+                if (change < 0) {
+                    currentIndentation += change;
+                }
+            }
+
+            if (stringified === "") {
+                output.push("");
+            } else {
+                output.push(generateTabs(currentIndentation) + line.toString());
+            }
+
+            for (const change of indentationChanges) {
+                if (change > 0) {
+                    currentIndentation += change;
+                }
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Computes how a line's command changes indentation.
+     *
+     * @param line   Output GLS line.
+     * @returns How the line's command changes indentation.
+     */
+    private getIndentationChanges(line: GlsLine): number[] {
+        const command = this.commandsBag.getCommand(line.command);
+        const metadata = command.getMetadata();
+
+        return metadata.indentation;
+    }
+}

--- a/src/lineIndenter.ts
+++ b/src/lineIndenter.ts
@@ -1,4 +1,4 @@
-import { CommandsBag } from "general-language-syntax";
+import { CommandsBag, CommandsBagFactory } from "general-language-syntax";
 
 import { GlsLine } from "./glsLine";
 
@@ -22,7 +22,7 @@ const generateTabs = (amount: number): string => {
  * Indents GLS lines using their command metadata.
  */
 export class LineIndenter {
-    private readonly commandsBag: CommandsBag = CommandsBag.forLanguageName("TypeScript");
+    private readonly commandsBag: CommandsBag = CommandsBagFactory.forLanguageName("TypeScript");
 
     /**
      * Indents GLS lines using their command metadata.

--- a/src/printing.ts
+++ b/src/printing.ts
@@ -1,10 +1,20 @@
 import { GlsLine } from "./glsLine";
+import { LineIndenter } from "./lineIndenter";
 import { Transformation } from "./transformation";
 
 /**
  * Prints series of transformations as lines of GLS.
  */
 export interface ITransformationsPrinter {
+    /**
+     * Prints a series of transformations as indented lines.
+     *
+     * @param sourceText   Full source text from the transforming file.
+     * @param transformations   A series of transformations.
+     * @returns The transformations' equivalent indented lines.
+     */
+    printFile(sourceText: string, transformations: Transformation[]): string[];
+
     /**
      * Prints a series of transformations as lines of GLS and literal string lines.
      *
@@ -35,6 +45,22 @@ const countEndlinesWithin = (text: string): number => {
  */
 export class TransformationsPrinter implements ITransformationsPrinter {
     /**
+     * Indents GLS lines using their command metadata.
+     */
+    private readonly lineIndenter: LineIndenter = new LineIndenter();
+
+    /**
+     * Prints a series of transformations as indented lines.
+     *
+     * @param sourceText   Full source text from the transforming file.
+     * @param transformations   A series of transformations.
+     * @returns The transformations' equivalent indented lines.
+     */
+    public printFile(sourceText: string, transformations: Transformation[]): string[] {
+        return this.lineIndenter.indent(this.printTransformations(sourceText, transformations));
+    }
+
+    /**
      * Prints a series of transformations as lines of GLS and literal string lines.
      *
      * @param sourceText   Full source text from the transforming file.
@@ -57,6 +83,7 @@ export class TransformationsPrinter implements ITransformationsPrinter {
 
             lines.push(...this.printTransformation(sourceText, transformations[i]));
         }
+
         return lines;
     }
 

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -46,7 +46,7 @@ export class Transformer {
      * @returns GLS equivalent for the source file.
      */
     public transformSourceFile(sourceFile: SourceFile, typeChecker?: TypeChecker): (string | GlsLine)[] {
-        return this.dependencies.printer.printTransformations(
+        return this.dependencies.printer.printFile(
             sourceFile.getFullText(sourceFile),
             this.getSourceFileTransforms(sourceFile, typeChecker));
     }
@@ -58,7 +58,7 @@ export class Transformer {
      * @returns GLS equivalent for the source text.
      */
     public transformText(sourceText: string): (string | GlsLine)[] {
-        return this.dependencies.printer.printTransformations(
+        return this.dependencies.printer.printFile(
             sourceText,
             this.getTextTransforms(sourceText));
     }

--- a/test/integration/break/expected.gls
+++ b/test/integration/break/expected.gls
@@ -1,13 +1,13 @@
 comment line
 while start : true
-break
+    break
 while end
 
 for numbers start : i int 0 7
-break
+    break
 for numbers end
 
 for each start : { list initialize : string "abc" "def" } string word
-break
+    break
 for each end
 comment line

--- a/test/integration/constructor/expected.gls
+++ b/test/integration/constructor/expected.gls
@@ -1,44 +1,44 @@
 comment line
 class start : PublicImplicitNoParameters
-constructor start : public
-constructor end
+    constructor start : public
+    constructor end
 class end
 
 class start : PublicExplicitNoParameters
-constructor start : public
-constructor end
+    constructor start : public
+    constructor end
 class end
 
 class start : ProtectedNoParameters
-constructor start : protected
-constructor end
+    constructor start : protected
+    constructor end
 class end
 
 class start : PrivateNoParameters
-constructor start : private
-constructor end
+    constructor start : private
+    constructor end
 class end
 
 class start : OneParameter
-constructor start : public abc string
-constructor end
+    constructor start : public abc string
+    constructor end
 class end
 
 class start : OneParameterContent
-constructor start : public abc string
-print : abc
-constructor end
+    constructor start : public abc string
+        print : abc
+    constructor end
 class end
 
 class start : TwoParameters
-constructor start : public abc string def OneParameter
-constructor end
+    constructor start : public abc string def OneParameter
+    constructor end
 class end
 
 class start : TwoParametersContent
-constructor start : public abc string def OneParameter
-print : abc
-print : def
-constructor end
+    constructor start : public abc string def OneParameter
+        print : abc
+        print : def
+    constructor end
 class end
 comment line

--- a/test/integration/continue/expected.gls
+++ b/test/integration/continue/expected.gls
@@ -1,13 +1,13 @@
 comment line
 while start : true
-continue
+    continue
 while end
 
 for numbers start : i int 0 7
-continue
+    continue
 for numbers end
 
 for each start : { list initialize : string "abc" "def" } string word
-continue
+    continue
 for each end
 comment line

--- a/test/integration/interface/expected.gls
+++ b/test/integration/interface/expected.gls
@@ -1,15 +1,15 @@
 comment line
 interface start : IAbc
-interface method : Abc void
-interface method : Bcd string i float
-interface method : Cde IAbc j boolean k string
+    interface method : Abc void
+    interface method : Bcd string i float
+    interface method : Cde IAbc j boolean k string
 interface end
 
 interface start : IDef IAbc
-interface method : Def void
+    interface method : Def void
 interface end
 
 interface start : IGhi IAbc IDef
-interface method : Ghi IGhi abc IAbc def IDef
+    interface method : Ghi IGhi abc IAbc def IDef
 interface end
 comment line

--- a/test/integration/member function/expected.gls
+++ b/test/integration/member function/expected.gls
@@ -1,16 +1,16 @@
 comment line
 class start : Abc
-member function declare start : public Explicits string
-return : ""
-member function declare end
+    member function declare start : public Explicits string
+        return : ""
+    member function declare end
 
-member function declare start : public Implicits Abc
-member function : private { this } Parameters "" 0
-return : { new : Abc }
-member function declare end
+    member function declare start : public Implicits Abc
+        member function : private { this } Parameters "" 0
+        return : { new : Abc }
+    member function declare end
 
-member function declare start : private Parameters void first string second float
-member function : public { this } Explicits
-member function declare end
+    member function declare start : private Parameters void first string second float
+        member function : public { this } Explicits
+    member function declare end
 class end
 comment line

--- a/test/integration/member variable/expected.gls
+++ b/test/integration/member variable/expected.gls
@@ -1,17 +1,17 @@
 comment line
 class start : Abc
-member variable declare : public explicits string "def"
+    member variable declare : public explicits string "def"
 
-member variable declare : public implicits int 7
+    member variable declare : public implicits int 7
 
-member variable declare : protected infinite Abc
+    member variable declare : protected infinite Abc
 
-member variable declare : private array { list type : string } { list initialize : string "ghi" }
+    member variable declare : private array { list type : string } { list initialize : string "ghi" }
 
-constructor start : public
-operation : { member variable : protected { this } infinite } equals { new : Abc }
-operation : { member variable : private { this } array } equals { list initialize : string "jkl" }
-constructor end
+    constructor start : public
+        operation : { member variable : protected { this } infinite } equals { new : Abc }
+        operation : { member variable : private { this } array } equals { list initialize : string "jkl" }
+    constructor end
 class end
 
 variable : abc Abc { new : Abc }

--- a/test/integration/static function/expected.gls
+++ b/test/integration/static function/expected.gls
@@ -1,16 +1,16 @@
 comment line
 class start : Abc
-static function declare start : public Explicits string
-return : ""
-static function declare end
+    static function declare start : public Explicits string
+        return : ""
+    static function declare end
 
-static function declare start : public Implicits Abc
-static function : private Abc Parameters "" 0
-return : { new : Abc }
-static function declare end
+    static function declare start : public Implicits Abc
+        static function : private Abc Parameters "" 0
+        return : { new : Abc }
+    static function declare end
 
-static function declare start : private Parameters void first string second float
-static function : public Abc Explicits
-static function declare end
+    static function declare start : private Parameters void first string second float
+        static function : public Abc Explicits
+    static function declare end
 class end
 comment line


### PR DESCRIPTION
Uses the new GLS@0.3.19 command metadata and GLS@0.3.20 `CommandsBagFactory` to get how each command should change the GLS source. Adds a `printFile` to printing for these root-level indentation changes.

Fixes #7.